### PR TITLE
Only hide the keyboard when going back to another screen.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=0.9.2
+PROJECT_VERSION=0.9.3
 PROJECT_GROUP_ID=com.jaynewstrom
 PROJECT_VCS_URL=https://github.com/JayNewstrom/ScreenSwitcher.git
 PROJECT_DESCRIPTION=ScreenSwitcher - A FragmentManager alternative

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.java
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.java
@@ -74,8 +74,6 @@ final class RealScreenSwitcher implements ScreenSwitcher {
         ensureTransitionIsNotOccurring("pop");
         checkNumberToPop(numberToPop);
 
-        hideKeyboard();
-
         if (!popListenerConsumedPop(numberToPop)) {
             performPop(numberToPop);
         }
@@ -166,6 +164,7 @@ final class RealScreenSwitcher implements ScreenSwitcher {
     private void performPop(int numberToPop) {
         List<Screen> screens = state.getScreens();
         if (screens.size() > numberToPop) {
+            hideKeyboard();
             for (int i = 1; i < numberToPop; i++) {
                 removeScreen(screens.get(screens.size() - i - 1));
             }


### PR DESCRIPTION
When popping the last screen(s) creating the bitmap and hiding the keyboard causes the view to get stretched and not look right.