### PR TITLE
Fix packaging options.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ subprojects {
     }
 
     configureKotlinLint(it)
-    configureAndroidPlugin(it)
 }
 
 static def configureKotlinLint(Project project) {
@@ -96,19 +95,4 @@ static def configureKotlinLint(Project project) {
     }
     project.plugins.withId('kotlin-android', closure)
     project.plugins.withId('kotlin', closure)
-}
-
-static def configureAndroidPlugin(Project project) {
-    def closure = {
-        project.android {
-            packagingOptions {
-                exclude 'META-INF/*.kotlin_module'
-                exclude 'kotlin/**'
-                exclude 'META-INF/*.version'
-            }
-        }
-    }
-
-    project.plugins.withId('com.android.application', closure)
-    project.plugins.withId('com.android.library', closure)
 }


### PR DESCRIPTION
These were previously excluded to prevent collisions. However, these are needed to properly export extension functions. As long as these are are excluded out of the final APK, there should be any issues.