### PR TITLE
Remove old screens before adding new screens for #replaceScreensWith

### DIFF
--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
@@ -106,6 +106,9 @@ internal class RealScreenSwitcher(
 
             state.lifecycleListener.onScreenBecameInactive(backgroundScreen)
 
+            // Remove the previous screens from state before adding the new ones.
+            val onTransitionCompleted = RemoveScreenRunnable(screensToRemove)
+
             for (screen in screens) {
                 state.addScreen(screen)
                 val view = createView(screen)
@@ -117,7 +120,6 @@ internal class RealScreenSwitcher(
             topView.visibility = View.VISIBLE
             state.lifecycleListener.onScreenBecameActive(topScreen)
 
-            val onTransitionCompleted = RemoveScreenRunnable(screensToRemove)
             topScreen.transition().transitionIn(topView, backgroundView, onTransitionCompleted)
         }
     }

--- a/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenTestUtils.kt
+++ b/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenTestUtils.kt
@@ -40,11 +40,14 @@ internal object ScreenTestUtils {
         return ScreenSwitcherFactory.activityScreenSwitcher(activity, state, popHandler) as RealScreenSwitcher
     }
 
-    fun mockCreateView(screen: Screen): View {
+    fun mockCreateView(screen: Screen, createViewCallback: (() -> Unit)? = null): View {
         val view = mock(View::class.java)
         val context = mock(Context::class.java)
         `when`(view.context).thenReturn(context)
-        `when`(screen.createView(kotlinAny(), kotlinAny())).thenReturn(view)
+        `when`(screen.createView(kotlinAny(), kotlinAny())).thenAnswer {
+            createViewCallback?.invoke()
+            view
+        }
         return view
     }
 


### PR DESCRIPTION
This is important because screens rely on the state to be accurate when creating their views.