### PR TITLE
Introduce a new mode to prevent exceptions

### DIFF
--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/NoScreenFoundScreen.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/NoScreenFoundScreen.kt
@@ -1,0 +1,23 @@
+package com.jaynewstrom.screenswitcher
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+
+/**
+ * A dummy screen to prevent exceptions from being thrown for APIs that expect a screen.
+ * See [ScreenSwitcherConfig.failSilentlyWhenPossible].
+ */
+object NoScreenFoundScreen : Screen {
+    override fun createView(context: Context, hostView: ViewGroup): View {
+        throw UnsupportedOperationException("createView should not be called on NoScreenFoundScreen.")
+    }
+
+    override fun destroyScreen(viewToDestroy: View) {
+        throw UnsupportedOperationException("destroyScreen should not be called on NoScreenFoundScreen.")
+    }
+
+    override fun transition(): ScreenTransition {
+        throw UnsupportedOperationException("transition should not be called on NoScreenFoundScreen.")
+    }
+}

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ScreenSwitcherConfig.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ScreenSwitcherConfig.kt
@@ -1,0 +1,19 @@
+package com.jaynewstrom.screenswitcher
+
+/**
+ * Contains global config for the library.
+ */
+object ScreenSwitcherConfig {
+    /**
+     * Defines error handling behavior for failures.
+     *
+     * Often times APIs that reference this property will return a [NoScreenFoundScreen] instead of throwing an
+     * exception.
+     */
+    var failSilentlyWhenPossible: Boolean = false
+
+    /**
+     * Logs warnings associated with the screen switcher.
+     */
+    var logger: ((message: String) -> Unit) = {}
+}

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ViewExtensions.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ViewExtensions.kt
@@ -27,6 +27,14 @@ tailrec fun View.associatedScreen(): Screen {
     if (screen != null) {
         return screen
     }
+
+    // When we detect we found the screen switcher, but no screen, return a dummy screen, rather than crashing on the
+    // next recursion.
+    if (ScreenSwitcherConfig.failSilentlyWhenPossible && getTag(R.id.screen_switcher) != null) {
+        ScreenSwitcherConfig.logger("Returning NoScreenFoundScreen from #associatedScreen - $this")
+        return NoScreenFoundScreen
+    }
+
     return parent.associatedScreen()
 }
 
@@ -77,6 +85,16 @@ tailrec fun View.screenSwitcherData(): ScreenSwitcherViewExtensionData {
         val screenSwitcherState = parent.getTag(R.id.screen_switcher_state) as ScreenSwitcherState
         return ScreenSwitcherViewExtensionData(screenSwitcher, screenSwitcherState, screen, parent)
     }
+
+    // When we detect we found the screen switcher, but no screen, return a dummy screen, rather than crashing on the
+    // next recursion.
+    if (ScreenSwitcherConfig.failSilentlyWhenPossible && getTag(R.id.screen_switcher) != null) {
+        ScreenSwitcherConfig.logger("Returning ScreenSwitcherViewExtensionData with NoScreenFoundScreen from #screenSwitcherData - $this")
+        val screenSwitcher = getTag(R.id.screen_switcher) as ScreenSwitcher
+        val screenSwitcherState = getTag(R.id.screen_switcher_state) as ScreenSwitcherState
+        return ScreenSwitcherViewExtensionData(screenSwitcher, screenSwitcherState, NoScreenFoundScreen, parent)
+    }
+
     return parent.screenSwitcherData()
 }
 

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ViewExtensions.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/ViewExtensions.kt
@@ -89,7 +89,8 @@ tailrec fun View.screenSwitcherData(): ScreenSwitcherViewExtensionData {
     // When we detect we found the screen switcher, but no screen, return a dummy screen, rather than crashing on the
     // next recursion.
     if (ScreenSwitcherConfig.failSilentlyWhenPossible && getTag(R.id.screen_switcher) != null) {
-        ScreenSwitcherConfig.logger("Returning ScreenSwitcherViewExtensionData with NoScreenFoundScreen from #screenSwitcherData - $this")
+        ScreenSwitcherConfig.logger("Returning ScreenSwitcherViewExtensionData with NoScreenFoundScreen from " +
+            "#screenSwitcherData - $this")
         val screenSwitcher = getTag(R.id.screen_switcher) as ScreenSwitcher
         val screenSwitcherState = getTag(R.id.screen_switcher_state) as ScreenSwitcherState
         return ScreenSwitcherViewExtensionData(screenSwitcher, screenSwitcherState, NoScreenFoundScreen, parent)


### PR DESCRIPTION
Exceptions could happen in extreme edge cases, this change makes it so those edge cases no-op, rather than crash.

It's recommended to only turn this mode on when in release mode.