### PR TITLE
Add the ability to listen to ScreenSwitcher creation from ScreenSwitcherState.

### DIFF
--- a/dialog-manager/build.gradle
+++ b/dialog-manager/build.gradle
@@ -20,4 +20,5 @@ dependencies {
     api deps.concrete
     api deps.kotlinRuntime
     api project(':screen-manager')
+    implementation deps.timber
 }

--- a/sample-core/build.gradle
+++ b/sample-core/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(':screen-switcher')
     api deps.appCompat
     api deps.dagger
-    implementation deps.timber
+    api deps.timber
     api deps.rxJava
     implementation deps.rxRelay
 }

--- a/sample-core/src/main/java/com/jaynewstrom/screenswitchersample/core/ViewPresenter.kt
+++ b/sample-core/src/main/java/com/jaynewstrom/screenswitchersample/core/ViewPresenter.kt
@@ -42,4 +42,9 @@ abstract class ViewPresenter(protected val view: View) {
     fun <T> registerObservable(observable: Observable<T>, subscriber: (t: T) -> Unit): () -> Disposable? {
         return view.registerObservable(observable, subscriber)
     }
+
+    fun <T> registerStateHolder(stateHolder: StateHolder<T>, subscriber: (t: T) -> Unit): () -> Disposable? {
+        subscriber(stateHolder.state)
+        return registerObservable(stateHolder.stateObservable, subscriber)
+    }
 }

--- a/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/FirstPresenter.kt
+++ b/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/FirstPresenter.kt
@@ -29,5 +29,9 @@ internal class FirstPresenter private constructor(private val view: View, compon
         view.findViewById<View>(R.id.btn_show_first_dialog).setOnClickListener {
             view.dialogDisplayer()?.show(dialogFactoryProvider.get())
         }
+
+        view.findViewById<View>(R.id.btn_show_navigate_dialog).setOnClickListener {
+            view.dialogDisplayer()?.show(NavigateDialogFactory())
+        }
     }
 }

--- a/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/FirstScreen.kt
+++ b/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/FirstScreen.kt
@@ -35,6 +35,7 @@ private class FirstScreen(private val navigator: FirstNavigator) : BaseScreen<Fi
 @Component(modules = [FirstModule::class])
 internal interface FirstComponent {
     fun inject(presenter: FirstPresenter)
+    fun inject(presenter: NavigateDialogPresenter)
 }
 
 @Module

--- a/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/NavigateDialogFactory.kt
+++ b/sample-screen-first/src/main/java/com/jaynewstrom/screenswitchersample/first/NavigateDialogFactory.kt
@@ -1,0 +1,28 @@
+package com.jaynewstrom.screenswitchersample.first
+
+import android.app.Dialog
+import android.content.Context
+import com.jaynewstrom.screenswitcher.dialogmanager.DialogFactory
+import com.jaynewstrom.screenswitchersample.core.ViewPresenter
+import javax.inject.Inject
+
+internal class NavigateDialogFactory @Inject constructor() : DialogFactory {
+    override fun createDialog(context: Context): Dialog {
+        val dialog = Dialog(context)
+        dialog.setContentView(R.layout.navigate_dialog)
+        NavigateDialogPresenter(dialog)
+        return dialog
+    }
+}
+
+internal class NavigateDialogPresenter(private val dialog: Dialog) : ViewPresenter(dialog) {
+    @Inject lateinit var navigator: FirstNavigator
+
+    init {
+        component<FirstComponent>().inject(this)
+        bindClick(R.id.navigate_to_second_screen_button) {
+            navigator.pushToSecondScreen(view)
+            dialog.dismiss()
+        }
+    }
+}

--- a/sample-screen-first/src/main/res/layout/first_view.xml
+++ b/sample-screen-first/src/main/res/layout/first_view.xml
@@ -36,4 +36,11 @@
         android:layout_height="wrap_content"
         android:text="@string/show_first_dialog"
         />
+
+    <Button
+        android:id="@+id/btn_show_navigate_dialog"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/show_navigate_dialog"
+        />
 </LinearLayout>

--- a/sample-screen-first/src/main/res/layout/navigate_dialog.xml
+++ b/sample-screen-first/src/main/res/layout/navigate_dialog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minWidth="300dp"
+    android:orientation="vertical"
+    >
+
+    <Button
+        android:id="@+id/navigate_to_second_screen_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/second_screen"
+        />
+</LinearLayout>

--- a/sample-screen-first/src/main/res/values/strings.xml
+++ b/sample-screen-first/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="second_screen">Second Screen</string>
     <string name="replace_with_second_screen">Replace with second screen</string>
     <string name="show_first_dialog">Show First Dialog</string>
+    <string name="show_navigate_dialog">Navigate</string>
 </resources>

--- a/screen-switcher-sample/src/androidTest/java/com/jaynewstrom/screenswitchersample/activity/MainActivityTest.kt
+++ b/screen-switcher-sample/src/androidTest/java/com/jaynewstrom/screenswitchersample/activity/MainActivityTest.kt
@@ -115,6 +115,21 @@ class MainActivityTest {
         onView(withText("Decrement 1")).perform(click(), click(), click(), click())
         onView(withTextView(id = R.id.bottom_bar_badge_text_view, text = "4")).check(matches(isDisplayed()))
     }
+
+    @Test fun testDialogWithNavigationWorks() {
+        onView(withId(R.id.btn_show_navigate_dialog)).perform(click())
+        onView(withId(R.id.navigate_to_second_screen_button)).perform(click())
+        pressBack()
+        onView(withId(R.id.btn_confirm_pop)).perform(click())
+        onView(withId(R.id.btn_show_navigate_dialog)).perform(click())
+        activityTestRule.recreateActivity()
+        onView(withId(R.id.navigate_to_second_screen_button)).perform(click())
+        pressBack()
+        onView(withId(R.id.btn_confirm_pop)).check(matches(isDisplayed())).perform(click())
+
+        // Ensure removing the screen doesn't leak anything!
+        onView(withId(R.id.btn_replace_with_second)).perform(click())
+    }
 }
 
 private fun ActivityTestRule<*>.recreateActivity() {

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
@@ -35,6 +35,7 @@ internal class RealScreenSwitcher(
         this.screenViewMap = LinkedHashMap()
         host.hostView().setupForViewExtensions(this, state)
         setupHostViewForHidingKeyboard()
+        state.screenSwitcherCreated(this)
         initializeViewState()
     }
 
@@ -51,9 +52,9 @@ internal class RealScreenSwitcher(
         val view = screen.createView(host.hostView(), state)
         view.setTag(R.id.screen_switcher_screen, screen)
         screenViewMap[screen] = view
-        screen.bindView(view)
-        checkArgument(view.parent == null) { "createView/bindView should not return a view that has a parent." }
+        checkArgument(view.parent == null) { "createView should not return a view that has a parent." }
         host.addView(view)
+        screen.bindView(view)
         state.removeViewHierarchyState(screen)?.let(view::restoreHierarchyState)
         return view
     }

--- a/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenSwitcherTest.kt
+++ b/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenSwitcherTest.kt
@@ -80,4 +80,15 @@ class ScreenSwitcherTest {
         verify(view1, never()).restoreHierarchyState(kotlinAny())
         verify(view2, never()).restoreHierarchyState(kotlinAny())
     }
+
+    @Test fun ensureScreenSwitcherCreatedListenerIsCalled() {
+        val screen1 = mock(Screen::class.java)
+        ScreenTestUtils.mockCreateView(screen1)
+        val activity = mock(Activity::class.java)
+        val state = ScreenTestUtils.defaultState(screen1)
+        val listener = mock(ScreenSwitcherState.ScreenSwitcherCreatedListener::class.java)
+        state.registerScreenSwitcherCreatedListener(screen1, listener)
+        ScreenTestUtils.testScreenSwitcher(activity, state)
+        verify(listener).screenSwitcherCreated(kotlinAny())
+    }
 }

--- a/tab-bar/src/main/java/com/jaynewstrom/screenswitcher/tabbar/TabBarPresenter.kt
+++ b/tab-bar/src/main/java/com/jaynewstrom/screenswitcher/tabbar/TabBarPresenter.kt
@@ -37,7 +37,7 @@ internal class TabBarPresenter(view: View, component: TabBarComponent) :
         content.saveStateDelegate = this
         addItemsToContainer()
 
-        registerObservable(currentTabBarItemStateHolder.stateObservable, ::setContentView)
+        registerStateHolder(currentTabBarItemStateHolder, ::setContentView)
     }
 
     private fun addItemsToContainer() {


### PR DESCRIPTION
Closes #130

Also adds the functionality and full end to end tests to make sure you can navigate to another screen from a dialog.