### PR TITLE
Revert behavior change to add the view to window before calling bindView.

### DIFF
--- a/dialog-manager/src/main/java/com/jaynewstrom/screenswitcher/dialogmanager/DialogManager.kt
+++ b/dialog-manager/src/main/java/com/jaynewstrom/screenswitcher/dialogmanager/DialogManager.kt
@@ -120,6 +120,7 @@ class DialogDisplayer internal constructor(
     private val screen: Screen = screenSwitcherData.screen
     private val screenSwitcherState: ScreenSwitcherState = screenSwitcherData.screenSwitcherState
     private var screenSwitcher: ScreenSwitcher? = null
+    private var parentViewForViewExtensionSetup: View? = null
 
     init {
         screenSwitcherData.screenSwitcherState.registerScreenSwitcherCreatedListener(screen, this)
@@ -137,6 +138,7 @@ class DialogDisplayer internal constructor(
             contentView.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
                 override fun onViewDetachedFromWindow(v: View) {
                     screenSwitcher = null
+                    parentViewForViewExtensionSetup = null
                 }
 
                 override fun onViewAttachedToWindow(v: View) {
@@ -144,12 +146,19 @@ class DialogDisplayer internal constructor(
             })
             contentView.setTag(R.id.screen_switcher_screen, screen)
             val parent = contentView.parent as View
-            parent.setupForViewExtensions(screenSwitcher!!, screenSwitcherState)
+            val localScreenSwitcher = screenSwitcher
+            if (localScreenSwitcher == null) {
+                parentViewForViewExtensionSetup = parent
+            } else {
+                parent.setupForViewExtensions(localScreenSwitcher, screenSwitcherState)
+            }
             return dialog
         }
     }
 
     override fun screenSwitcherCreated(screenSwitcher: ScreenSwitcher) {
         this.screenSwitcher = screenSwitcher
+        parentViewForViewExtensionSetup?.setupForViewExtensions(screenSwitcher, screenSwitcherState)
+        parentViewForViewExtensionSetup = null
     }
 }

--- a/espresso-testing-bootstrap/src/main/java/screenswitchersample/espressotestingbootstrap/test/ActivityTestRuleExtensions.kt
+++ b/espresso-testing-bootstrap/src/main/java/screenswitchersample/espressotestingbootstrap/test/ActivityTestRuleExtensions.kt
@@ -1,10 +1,13 @@
 package screenswitchersample.espressotestingbootstrap.test
 
 import android.os.SystemClock
+import android.view.ViewGroup
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.rule.ActivityTestRule
+import com.jaynewstrom.screenswitcher.Screen
 import org.hamcrest.CoreMatchers
+import screenswitchersample.espressotestingbootstrap.R
 
 fun ActivityTestRule<*>.recreateActivity() {
     val previousHashCode = activity.hashCode()
@@ -19,4 +22,9 @@ fun ActivityTestRule<*>.recreateActivity() {
 
 fun ViewInteraction.notInActivityWindow(rule: ActivityTestRule<*>): ViewInteraction {
     return inRoot(RootMatchers.withDecorView(CoreMatchers.not(CoreMatchers.`is`(rule.activity.window.decorView))))
+}
+
+fun <T : Screen> ActivityTestRule<*>.currentScreen(): T {
+    @Suppress("UNCHECKED_CAST")
+    return activity.findViewById<ViewGroup>(R.id.screen_host).getChildAt(0).getTag(R.id.screen_switcher_screen) as T
 }

--- a/screen-switcher/build.gradle
+++ b/screen-switcher/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     testImplementation deps.junit
     testImplementation deps.mockitoCore
     testImplementation deps.fest
+
+    androidTestImplementation project(':sample-core')
 }
 
 task sourcesJar(type: Jar) {
@@ -60,3 +62,5 @@ bintray {
         }
     }
 }
+
+apply from: rootProject.file('espresso-testing-bootstrap/espressoTestingBootstrap.gradle')

--- a/screen-switcher/src/androidTest/java/com/jaynewstrom/screenswitcher/GenericScreenTest.kt
+++ b/screen-switcher/src/androidTest/java/com/jaynewstrom/screenswitcher/GenericScreenTest.kt
@@ -1,0 +1,76 @@
+package com.jaynewstrom.screenswitcher
+
+import android.graphics.Color
+import android.view.View
+import android.view.ViewGroup
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBackUnconditionally
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import screenswitchersample.core.screen.DefaultScreenTransition
+import screenswitchersample.espressotestingbootstrap.matchers.withBackgroundColor
+import screenswitchersample.espressotestingbootstrap.test.ScreenTestRule
+import screenswitchersample.espressotestingbootstrap.test.TestScreenFactory
+import screenswitchersample.espressotestingbootstrap.test.currentScreen
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+internal class GenericScreenTest {
+    @get:Rule val screenTestRule = ScreenTestRule(GenericTestScreenFactory::class.java)
+
+    // Having the view not be attached to the window makes things significantly easier when dealing with lifecycle stuff.
+    // This ensures view.addOnAttachStateChangeListener calls will be symmetric.
+    @Test fun testBindView_ViewNotAttachedToWindow() {
+        screenTestRule.showScreen()
+        onView(withBackgroundColor("#123456")).check(matches(isDisplayed()))
+        val screenEvents = screenTestRule.currentScreen<GenericScreen>().screenEvents
+        pressBackUnconditionally() // Finish the activity.
+        assertThat(screenEvents.await(5, TimeUnit.SECONDS)).isTrue
+        assertThat(screenEvents.count).isZero
+    }
+}
+
+class GenericTestScreenFactory : TestScreenFactory {
+    override fun createScreen(): Screen {
+        return GenericScreen()
+    }
+}
+
+class GenericScreen : Screen {
+    val screenEvents = CountDownLatch(5)
+
+    override fun createView(hostView: ViewGroup, screenSwitcherState: ScreenSwitcherState): View {
+        screenEvents.countDown()
+        val view = View(hostView.context)
+        view.setBackgroundColor(Color.parseColor("#123456"))
+        return view
+    }
+
+    override fun bindView(view: View) {
+        view.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewDetachedFromWindow(v: View) {
+                screenEvents.countDown()
+            }
+
+            override fun onViewAttachedToWindow(v: View) {
+                screenEvents.countDown()
+            }
+        })
+
+        assertThat(view.isAttachedToWindow).isFalse
+        screenEvents.countDown()
+    }
+
+    override fun destroyScreen(associatedView: View) {
+        assertThat(associatedView.isAttachedToWindow).isTrue
+        screenEvents.countDown()
+    }
+
+    override fun transition(): Screen.Transition = DefaultScreenTransition
+}

--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
@@ -52,9 +52,9 @@ internal class RealScreenSwitcher(
         val view = screen.createView(host.hostView(), state)
         view.setTag(R.id.screen_switcher_screen, screen)
         screenViewMap[screen] = view
-        checkArgument(view.parent == null) { "createView should not return a view that has a parent." }
-        host.addView(view)
         screen.bindView(view)
+        checkArgument(view.parent == null) { "createView/bindView should not return a view that has a parent." }
+        host.addView(view)
         state.removeViewHierarchyState(screen)?.let(view::restoreHierarchyState)
         return view
     }

--- a/tab-bar/src/main/java/com/jaynewstrom/screenswitcher/tabbar/TabBarPresenter.kt
+++ b/tab-bar/src/main/java/com/jaynewstrom/screenswitcher/tabbar/TabBarPresenter.kt
@@ -37,7 +37,7 @@ internal class TabBarPresenter(view: View, component: TabBarComponent) :
         content.saveStateDelegate = this
         addItemsToContainer()
 
-        registerStateHolder(currentTabBarItemStateHolder, ::setContentView)
+        registerObservable(currentTabBarItemStateHolder.stateObservable, ::setContentView)
     }
 
     private fun addItemsToContainer() {


### PR DESCRIPTION
This was done in order to ease DialogManager requirements. However, it's not worth it, since it's nice to have symmetric view.addOnAttachStateChangeListener calls.

Reverted the change, and added some more strict tests around it.