### PR TITLE
Remove stacktrace of previous transition.

### DIFF
--- a/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
+++ b/screen-switcher/src/main/java/com/jaynewstrom/screenswitcher/RealScreenSwitcher.kt
@@ -13,20 +13,10 @@ internal class RealScreenSwitcher(
     private val state: ScreenSwitcherState,
     private val host: ScreenSwitcherHost
 ) : ScreenSwitcher {
-    private var transitioningStackTrace: Array<StackTraceElement>? = null
     private val activity: Activity
     private val screenViewMap: MutableMap<Screen, View>
 
     override var isTransitioning: Boolean = false
-        set(transitioning) {
-            field = transitioning
-
-            transitioningStackTrace = if (transitioning) {
-                Throwable().stackTrace
-            } else {
-                null
-            }
-        }
 
     init {
         checkArgument(state.screens.isNotEmpty()) { "state needs screens in order to initialize a ScreenSwitcher" }
@@ -150,9 +140,8 @@ internal class RealScreenSwitcher(
     private fun ensureTransitionIsNotOccurring(transitionType: String) {
         checkState(!isTransitioning) {
             String.format(
-                "Can't %s while a transition is occurring.\nPrevious transition from: %s",
-                transitionType,
-                transitioningStackTrace?.contentToString()
+                "Can't %s while a transition is occurring.",
+                transitionType
             )
         }
     }

--- a/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenSwitcherReplaceScreensWithTest.kt
+++ b/screen-switcher/src/test/java/com/jaynewstrom/screenswitcher/ScreenSwitcherReplaceScreensWithTest.kt
@@ -7,7 +7,6 @@ import com.jaynewstrom.screenswitcher.ScreenTestUtils.mockCreateView
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -71,28 +70,6 @@ class ScreenSwitcherReplaceScreensWithTest {
         assertThat(activityScreenSwitcher.isTransitioning).isTrue
         transitionCompletedRunnable.get().run()
         assertThat(activityScreenSwitcher.isTransitioning).isFalse
-    }
-
-    @Test fun givesPreviousStacktraceWhenCallingTransitionWhenTransitioning() {
-        val activity = mock(Activity::class.java)
-        val screen1 = mock(Screen::class.java)
-        mockCreateView(screen1)
-        val screen2 = mock(Screen::class.java)
-        mockCreateView(screen2)
-        `when`(screen2.transition()).thenReturn(mock(Screen.Transition::class.java))
-        val state = ScreenTestUtils.defaultState(listOf(screen1, screen2))
-        val activityScreenSwitcher = ScreenTestUtils.testScreenSwitcher(activity, state)
-        testCallingTransitionHelper(activityScreenSwitcher)
-        try {
-            activityScreenSwitcher.replaceScreensWith(1, listOf(mock(Screen::class.java)))
-            fail()
-        } catch (expected: IllegalStateException) {
-            assertThat(expected).hasMessageContaining("testCallingTransitionHelper")
-        }
-    }
-
-    private fun testCallingTransitionHelper(screenSwitcher: ScreenSwitcher) {
-        screenSwitcher.pop(1)
     }
 
     @Test fun enqueuedTransitionIsExecutedAfterReplace() {


### PR DESCRIPTION
This can pretty trivially be done by wrapping the screen switcher in a custom class that logs this information.